### PR TITLE
Only try to compile on linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,8 +6,7 @@
         ['OS=="linux"', {
           "include_dirs": [
             "<!(node -e \"require('nan')\")",
-            "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)",
-                      "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)"
+            "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)"
           ],
           "sources": [ "src/pitft.cc", "src/framebuffer.cc" ],
           "libraries": [

--- a/binding.gyp
+++ b/binding.gyp
@@ -2,19 +2,17 @@
   "targets": [
     {
       "target_name": "pitft",
-      "include_dirs": [
-        "<!(node -e \"require('nan')\")",
-        "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)"
-      ],
-      "sources": [ "src/pitft.cc", "src/framebuffer.cc" ],
       "conditions": [
         ['OS=="linux"', {
+          "include_dirs": [
+            "<!(node -e \"require('nan')\")",
+            "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)",
+                      "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)"
+          ],
+          "sources": [ "src/pitft.cc", "src/framebuffer.cc" ],
           "libraries": [
             "<!@(pkg-config cairo --libs)"
-          ],
-                    "include_dirs": [
-                      "<!@(pkg-config cairo --cflags-only-I | sed s/-I//g)"
-                    ]
+          ]
         }]
         ]
     }


### PR DESCRIPTION
With this change, I can now "npm install" pitft on OS X. It will of course not work, but this allows me to run my tests on the other code in my project.